### PR TITLE
fix: allow SVG uploads by skipping ImageSharp validation

### DIFF
--- a/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
@@ -318,7 +318,7 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         private void ValidateImageIfNeeded(string path, Stream stream)
         {
             var contentType = _mimeTypeResolver.Resolve(path);
-            if (!contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            if (!ImageSharpValidationFileTypes.RequiresValidation(path, contentType))
             {
                 return;
             }

--- a/src/AF.Umbraco.S3.Media.Storage/Core/ImageSharpValidationFileTypes.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Core/ImageSharpValidationFileTypes.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace AF.Umbraco.S3.Media.Storage.Core
+{
+
+    /// <summary>
+    /// Centralizes the file types that can be validated with the ImageSharp decoders bundled by this package.
+    /// </summary>
+    internal static class ImageSharpValidationFileTypes
+    {
+        private static readonly HashSet<string> ValidatedExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".bmp",
+            ".gif",
+            ".jpeg",
+            ".jpg",
+            ".pbm",
+            ".png",
+            ".qoi",
+            ".tga",
+            ".tif",
+            ".tiff",
+            ".webp"
+        };
+
+        private static readonly HashSet<string> ValidatedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "image/bmp",
+            "image/gif",
+            "image/jpeg",
+            "image/pbm",
+            "image/png",
+            "image/qoi",
+            "image/tga",
+            "image/tif",
+            "image/tiff",
+            "image/webp",
+            "image/x-portable-bitmap",
+            "image/x-tga",
+            "image/x-targa"
+        };
+
+        public static bool RequiresValidation(string fileNameOrPath, string contentType)
+        {
+            string extension = Path.GetExtension(fileNameOrPath);
+            if (!string.IsNullOrWhiteSpace(extension))
+            {
+                return ValidatedExtensions.Contains(extension);
+            }
+
+            return !string.IsNullOrWhiteSpace(contentType)
+                && ValidatedContentTypes.Contains(contentType);
+        }
+    }
+}

--- a/src/AF.Umbraco.S3.Media.Storage/Middlewares/AWSS3UploadValidationExceptionMiddleware.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Middlewares/AWSS3UploadValidationExceptionMiddleware.cs
@@ -1,3 +1,4 @@
+using AF.Umbraco.S3.Media.Storage.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Localization;
@@ -98,7 +99,7 @@ namespace AF.Umbraco.S3.Media.Storage.Middlewares
             IFormCollection form = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
             IFormFile invalidFile = null;
 
-            foreach (IFormFile file in form.Files.Where(IsImageCandidate))
+            foreach (IFormFile file in form.Files.Where(RequiresImageSharpValidation))
             {
                 await using Stream stream = file.OpenReadStream();
                 try
@@ -145,26 +146,11 @@ namespace AF.Umbraco.S3.Media.Storage.Middlewares
         }
 
         /// <summary>
-        /// Determines whether image candidate.
+        /// Determines whether the file should be validated with ImageSharp.
         /// </summary>
-        private static bool IsImageCandidate(IFormFile file)
+        private static bool RequiresImageSharpValidation(IFormFile file)
         {
-            if (!string.IsNullOrWhiteSpace(file.ContentType) &&
-                file.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            string extension = Path.GetExtension(file.FileName);
-            return extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".gif", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".webp", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".tif", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".tiff", StringComparison.OrdinalIgnoreCase)
-                || extension.Equals(".qoi", StringComparison.OrdinalIgnoreCase);
+            return ImageSharpValidationFileTypes.RequiresValidation(file.FileName, file.ContentType);
         }
 
         /// <summary>


### PR DESCRIPTION
## Title

Fix SVG uploads being rejected by ImageSharp validation

## Summary

This change fixes valid SVG uploads being rejected by the S3 media storage package.

The package previously treated any `image/*` file as something that should be validated with ImageSharp. That worked for raster image formats, but it broke for SVG because the bundled ImageSharp decoders do not support it. As a result, valid SVG files were rejected with `UnknownImageFormatException`.

## What changed

- limited ImageSharp-based validation to file types that are actually supported by the bundled decoders
- reused the same validation rules in both upload validation paths to keep behavior consistent
- preserved validation for supported raster image formats such as PNG, JPG, GIF, WebP, BMP, TIFF, and QOI

## Result

- valid SVG uploads are now accepted
- invalid raster image uploads are still rejected as before
- behavior is consistent between middleware-level validation and filesystem-level validation

## Testing

- built the package successfully
- built the Umbraco 17 test host successfully
- packed a local prerelease package and verified the fix in a consuming Umbraco project
- confirmed SVG upload works and raster image validation still behaves as expected