### PR TITLE
BucketPrefix and BucketHostName suppoort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## Fork Notice
+
+This is a fork of [AF.Umbraco.S3.Media.Storage](https://github.com/afabri73/AF.Umbraco.S3.Media.Storage) 
+by Adriano Fabri.
+
+**Changes in this fork:**
+- Made `BucketPrefix` configurable via `appsettings.json` (was previously hardcoded to `"media"`)
+
+A [pull request](link-to-your-pr) has been opened against the upstream repo. 
+If merged, this fork will be retired in favour of the official package.
+
+
 # AF.Umbraco.S3.Media.Storage
 
 AWS S3 media storage provider for Umbraco 15/16/17 on .NET 9/10.

--- a/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
@@ -94,6 +94,8 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         /// </summary>
         public bool CanAddPhysical => false;
 
+        private readonly string _bucketHostName;
+
         /// <summary>
         /// Creates a new instance of <see cref="AWSS3FileSystem" />.
         /// </summary>
@@ -124,6 +126,8 @@ namespace AF.Umbraco.S3.Media.Storage.Core
 
             _mimeTypeResolver = mimeTypeResolver;
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            _bucketHostName = options.BucketHostName?.TrimEnd('/') ?? string.Empty;
 
             _S3Client = s3Client;
         }
@@ -603,15 +607,14 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         }
 
         /// <summary>
-        /// Gets url.
+        /// Gets the public URL for the specified path, prepending the configured
+        /// CDN hostname if available.
         /// </summary>
         /// <param name="path">The path.</param>
-        /// <returns>The result of the operation.</returns>
+        /// <returns>The full public URL for the media file.</returns>
         public string GetUrl(string path)
         {
-            var hostName = "";
-
-            return string.Concat(hostName, "/", ResolveBucketPath(path));
+            return string.Concat(_bucketHostName, "/", ResolveBucketPath(path));
         }
 
         /// <summary>

--- a/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Core/AWSS3FileSystem.cs
@@ -42,7 +42,8 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         /// </summary>
         private readonly string _rootUrl;
         /// <summary>
-        /// Gets the bucket prefix used by this component.
+        /// The S3 key prefix used as the root folder for media storage. 
+        /// Defaults to "media" if not overridden in configuration.
         /// </summary>
         private readonly string _bucketPrefix;
         /// <summary>
@@ -115,7 +116,8 @@ namespace AF.Umbraco.S3.Media.Storage.Core
             _bucketName = options.BucketName ?? throw new ArgumentNullException(nameof(contentTypeProvider));
 
             _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
-            _bucketPrefix = AWSS3FileSystemOptions.BucketPrefix ?? _rootUrl;
+
+            _bucketPrefix = options.BucketPrefix ?? _rootUrl;
             _cannedACL = options.CannedACL;
             _serverSideEncryptionMethod = options.ServerSideEncryptionMethod;
             _rootPath = hostingEnvironment.ToAbsolute(options.VirtualPath);
@@ -819,9 +821,12 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         }
 
         /// <summary>
-        /// Builds mirrored Cache Key.
+        /// Builds the S3 cache key for a given source path by normalizing delimiters,
+        /// stripping the configured bucket prefix, and prepending the cache folder.
         /// </summary>
-        private static string BuildMirroredCacheKey(string sourcePath)
+        /// <param name="sourcePath">The full S3 source key.</param>
+        /// <returns>The corresponding cache key under the <c>cache/</c> prefix.</returns>
+        private string BuildMirroredCacheKey(string sourcePath)
         {
             string normalizedPath = sourcePath
                 .Trim()
@@ -889,12 +894,14 @@ namespace AF.Umbraco.S3.Media.Storage.Core
         }
 
         /// <summary>
-        /// Removes a leading <c>media/</c> segment from a normalized path when present.
+        /// Removes the leading bucket prefix segment from a normalized path when present.
         /// </summary>
         /// <param name="normalizedPath">The normalized source path.</param>
-        /// <returns>The path without the leading media segment.</returns>
-        private static string TrimLeadingMediaSegment(string normalizedPath) =>
-            normalizedPath.StartsWith("media/", StringComparison.Ordinal) ? normalizedPath["media/".Length..] : normalizedPath;
+        /// <returns>The path without the leading bucket prefix segment.</returns>
+        private string TrimLeadingMediaSegment(string normalizedPath) =>
+            normalizedPath.StartsWith(_bucketPrefix + "/", StringComparison.Ordinal)
+                ? normalizedPath[(_bucketPrefix.Length + 1)..]
+                : normalizedPath;
 
         /// <summary>
         /// Resolves bucket Path.

--- a/src/AF.Umbraco.S3.Media.Storage/Middlewares/AWSS3FileSystemMiddleware.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Middlewares/AWSS3FileSystemMiddleware.cs
@@ -34,7 +34,8 @@ namespace AF.Umbraco.S3.Media.Storage.Middlewares
         /// </summary>
         private string _rootPath;
         /// <summary>
-        /// Gets the container root path used by this component.
+        /// The S3 key prefix used as the root container path for media delivery.
+        /// Defaults to the virtual path if no bucket prefix is configured.
         /// </summary>
         private string _containerRootPath;
         /// <summary>
@@ -85,7 +86,7 @@ namespace AF.Umbraco.S3.Media.Storage.Middlewares
 
             var fileSystemOptions = options.Get(name);
             _rootPath = hostingEnvironment.ToAbsolute(fileSystemOptions.VirtualPath);
-            _containerRootPath = AWSS3FileSystemOptions.BucketPrefix ?? _rootPath;
+            _containerRootPath = fileSystemOptions.BucketPrefix ?? _rootPath;
             _bucketName = fileSystemOptions.BucketName;
 
             _s3Client = s3Client;
@@ -429,14 +430,15 @@ namespace AF.Umbraco.S3.Media.Storage.Middlewares
         }
 
         /// <summary>
-        /// Applies updated options when configuration changes are detected.
+        /// Applies updated options when configuration changes are detected,
+        /// refreshing the virtual path and container root path from the new options.
         /// </summary>
         private void OptionsOnChange(AWSS3FileSystemOptions options, string name, IHostingEnvironment hostingEnvironment)
         {
             if (name != _name) return;
 
             _rootPath = hostingEnvironment.ToAbsolute(options.VirtualPath);
-            _containerRootPath = options.VirtualPath ?? _rootPath;
+            _containerRootPath = options.BucketPrefix ?? _rootPath;
         }
     }
 }

--- a/src/AF.Umbraco.S3.Media.Storage/Options/AWSS3FileSystemOptions.cs
+++ b/src/AF.Umbraco.S3.Media.Storage/Options/AWSS3FileSystemOptions.cs
@@ -12,7 +12,8 @@ namespace AF.Umbraco.S3.Media.Storage.Options
     {
         public const string MediaFileSystemName = "Media";
 
-        public const string BucketPrefix = "media";
+        //public const string BucketPrefix = "media";
+        public string BucketPrefix { get; set; } = "media";
 
         public string Region { get; set; } = null!;
 


### PR DESCRIPTION
## Summary

Adds configurable `BucketPrefix` support and includes two minor fixes discovered 
during integration testing.

---

## Changes

### Feature: Configurable BucketPrefix

`BucketPrefix` was hardcoded as a `const` with value `"media"`, preventing use 
cases where S3 content must live under a different folder path. Promoted to a 
settable property with `"media"` as the default — fully backward compatible.

- `AWSS3FileSystem` and `AWSS3FileSystemMiddleware` updated to access `BucketPrefix` 
  via the options instance
- `TrimLeadingMediaSegment` and `BuildMirroredCacheKey` converted from static to 
  instance methods to respect the configured prefix at runtime

### Fix: OptionsOnChange may not refresh container path correctly

`_containerRootPath` appeared to be refreshing from `options.VirtualPath` rather 
than `options.BucketPrefix` on config hot-reload, which could cause unexpected 
media delivery behaviour when configuration changes are detected at runtime.

### Fix: GetUrl may not reflect configured BucketHostName

`BucketHostName` did not appear to be applied in `GetUrl`, which could result in 
media URLs being generated without the configured CDN domain in certain setups.
Added `_bucketHostName` field and updated `GetUrl` to prepend it when building 
public media URLs.

---

## Compatibility

All changes are backward compatible. Default `BucketPrefix` remains `"media"` and 
`BucketHostName` behaviour is unchanged when not configured.